### PR TITLE
Migrate all icons to Blazicons component library

### DIFF
--- a/SeedPlan.Client/Layout/MainLayout.razor
+++ b/SeedPlan.Client/Layout/MainLayout.razor
@@ -9,7 +9,7 @@
     <header class="main-header">
         <div class="header-content">
             <div class="brand" @onclick='() => Nav.NavigateTo("/")'>
-                <div class="logo-circle"><i data-lucide="leaf"></i></div>
+                <div class="logo-circle"><Blazicon Svg="MdiIcon.LeafCircleOutline" /></div>
                 <h1 class="app-title">SeedPlan</h1>
             </div>
             <div class="header-actions">
@@ -28,23 +28,23 @@
                 @* DEN NYA BOTTENMENYN *@
                 <nav class="bottom-nav">
                     <NavLink class="nav-item" href="" Match="NavLinkMatch.All">
-                        <i data-lucide="sun"></i>
+                        <Blazicon Svg="Lucide.Sun" />
                         <span>ÖVERSIKT</span>
                     </NavLink>
                     <NavLink class="nav-item" href="seeds">
-                        <i data-lucide="package"></i>
+                        <Blazicon Svg="MdiIcon.SeedOutline" />
                         <span>FRÖER</span>
                     </NavLink>
                     <NavLink class="nav-item" href="sowings">
-                        <i data-lucide="leaf"></i>
+                        <Blazicon Svg="MdiIcon.Sprout" />
                         <span>SÅDDER</span>
                     </NavLink>
                     <NavLink class="nav-item" href="guide">
-                        <i data-lucide="info"></i>
+                        <Blazicon Svg="MdiIcon.InformationSlabCircleOutline" />
                         <span>GUIDE</span>
                     </NavLink>
                     <NavLink class="nav-item" href="profile">
-                        <i data-lucide="settings"></i>
+                        <Blazicon Svg="Lucide.Settings" />
                         <span>INSTÄLLN.</span>
                     </NavLink>
                 </nav>
@@ -60,7 +60,7 @@
                 {
                     <div class="login-screen">
                         <div class="login-card">
-                            <div class="login-icon"><i data-lucide="lock"></i></div>
+                            <div class="login-icon"><Blazicon Svg="Lucide.Lock" /></div>
                             <h2>Välkommen tillbaka</h2>
                             <p>Logga in för att hantera din trädgård.</p>
                             <LoginForm />
@@ -88,7 +88,7 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        await JS.InvokeVoidAsync("initializeLucide");
+        
     }
 
     public void Dispose()

--- a/SeedPlan.Client/Layout/MainLayout.razor.css
+++ b/SeedPlan.Client/Layout/MainLayout.razor.css
@@ -33,13 +33,14 @@
 }
 
 .logo-circle {
-    background: #10b981;
-    color: white;
-    padding: 8px;
-    border-radius: 8px;
+    color: #10b981;
+    background: white;
+    padding: 0px;
+    border-radius: 50px;
     display: flex;
     align-items: center;
     justify-content: center;
+    font-size: 3rem;
 }
 
 .app-title {
@@ -76,6 +77,7 @@
     width: 64px;
     height: 64px;
     background: #f0fdf4;
+    font-size: 2rem;
     color: #10b981;
     border-radius: 50%;
     display: flex;
@@ -123,12 +125,13 @@
     color: #888888;
     flex: 1;
     height: 100%;
+
 }
 
-    ::deep .nav-item i {
-        width: 24px;
-        height: 24px;
+    ::deep .nav-item {
+        font-size: 2.1rem;
         display: block;
+        font-weight: 400;
     }
 
     ::deep .nav-item span {

--- a/SeedPlan.Client/Pages/AddSeedModal.razor
+++ b/SeedPlan.Client/Pages/AddSeedModal.razor
@@ -8,7 +8,7 @@
     <div class="sp-modal-overlay">
         <div class="sp-modal-card fade-in">
             <header class="sp-modal-header">
-                <h2>Lägg till frö <span>🌱</span></h2>
+                <h2>Lägg till frö <span><Blazicon Svg="MdiIcon.Seed" /></span></h2>
             </header>
 
             <div class="sp-modal-body">
@@ -115,7 +115,7 @@
     protected override async Task OnParametersSetAsync()
     {
         await Task.Delay(50);
-        await JS.InvokeVoidAsync("initializeLucide");
+      
     }
 
     protected override async Task OnInitializedAsync()

--- a/SeedPlan.Client/Pages/AddSowingModal.razor
+++ b/SeedPlan.Client/Pages/AddSowingModal.razor
@@ -113,7 +113,6 @@
             _wasVisible = false;
         }
         await Task.Delay(50);
-        await JS.InvokeVoidAsync("initializeLucide");
     }
 
     private async Task HandleSave()

--- a/SeedPlan.Client/Pages/EditSeedModal.razor
+++ b/SeedPlan.Client/Pages/EditSeedModal.razor
@@ -49,7 +49,7 @@
     protected override async Task OnParametersSetAsync()
     {
         await Task.Delay(50);
-        await JS.InvokeVoidAsync("initializeLucide");
+      
     }
 
     private async Task HandleSave()

--- a/SeedPlan.Client/Pages/Guide.razor
+++ b/SeedPlan.Client/Pages/Guide.razor
@@ -9,14 +9,13 @@
     <header class="guide-header">
         <h1 class="serif-title">Växtguide</h1>
         <button class="filter-toggle @(showFilters ? "active" : "")" @onclick="ToggleFilters">
-            <i data-lucide="filter"></i>
+            <Blazicon Svg="Lucide.Funnel" />
         </button>
     </header>
 
     @* SÖKRUTA *@
     <div class="search-section">
         <div class="search-wrapper">
-            <i data-lucide="info" class="search-icon"></i>
             <input type="text" value="@searchText" @oninput="OnSearchInput" placeholder="Sök växt..." class="search-input" />
         </div>
     </div>
@@ -60,7 +59,7 @@
             <div class="plant-card" @onclick="() => OpenPlantDetail(plant)">
                 <div class="card-top">
                     <div class="plant-icon-circle">
-                        <i data-lucide="leaf"></i>
+                        <Blazicon Svg="Lucide.Leaf" />
                     </div>
                     <span class="hardiness-badge @GetHardinessClass(plant.HardinessLevel)">
                         @GetHardinessText(plant.HardinessLevel)
@@ -76,14 +75,19 @@
                     <div class="feature-icons">
                         @if (plant.IsLightGerminating)
                         {
-                            <i data-lucide="sparkles" class="icon-light"></i>
+                            <div class="icon-light">
+                            <Blazicon Svg="Lucide.Sparkles" class="icon-light" />
+                            </div>
                         }
                         @if (plant.RequiresTopping)
-                        {
-                            <i data-lucide="scissors" class="icon-topping"></i>
+                        {<div class="icon-topping">
+                            <Blazicon Svg="Lucide.Scissors" class="icon-topping" />
+                            </div>
                         }
                     </div>
-                    <i data-lucide="chevron-right" class="arrow"></i>
+                    <div class="arrow">
+                        <Blazicon Svg="Lucide.ChevronRight" class="arrow" />
+                    </div>
                 </div>
             </div>
         }
@@ -166,7 +170,6 @@
         {
             await LoadFilters();
             StateHasChanged(); // Tvinga UI att uppdateras med de laddade filtren
-            await JS.InvokeVoidAsync("initializeLucide");
         }
     }
     private async Task SaveFilters()

--- a/SeedPlan.Client/Pages/Guide.razor.css
+++ b/SeedPlan.Client/Pages/Guide.razor.css
@@ -19,10 +19,8 @@
     height: 40px;
     color: #64748b;
     cursor: pointer;
+    font-size: 1.5rem;
 }
-
-
-
     .filter-toggle.active {
         background: #10b981;
         color: white;
@@ -33,15 +31,17 @@
 .search-wrapper {
     position: relative;
     margin-bottom: 2rem;
+    width: 94%;
 }
-
+/* Sökikonen */
 .search-icon {
     position: absolute;
     left: 15px;
     top: 50%;
     transform: translateY(-50%);
-    color: #cbd5e1;
+    color: #cbd5e1; /* Ändrat från color till stroke */
     width: 18px;
+    height: 18px; /* Lägg till höjd för säkerhets skull */
 }
 
 .search-input {
@@ -155,9 +155,6 @@
 .plant-card:hover {
     border-color: #10b981;
 }
-
-
-
     .plant-card:hover .plant-icon-circle {
         background: #10b981;
         color: white;
@@ -173,6 +170,7 @@
     align-items: center;
     justify-content: center;
     transition: all 0.2s ease;
+    font-size: 1.4rem;
 }
 
 .plant-name {
@@ -200,24 +198,27 @@
     display: flex;
     gap: 8px;
 }
-
-
-
-    .feature-icons i {
-        font-size: 14px;
+    .feature-icons svg {
+     font-size: 1rem;
     }
 
+
+/* Ljusgroende (Sparkles) */
 .icon-light {
-    color: #3b82f6;
+    color: #3b82f6 !important; /* Blå */
+    font-size: 1.2rem;
 }
 
+/* Toppas (Scissors) */
 .icon-topping {
-    color: #a855f7;
+    color: #a855f7 !important; /* Lila */
+    font-size: 1.2rem;
 }
 
+/* Pilen */
 .arrow {
-    color: #f1f5f9;
-    width: 16px;
+    color: #cbd5e1 !important; /* Ljusgrå (du hade #f1f5f9 som är nästan vit) */
+    font-size: 1.2rem;
 }
 /* HÄRDIGHET BADGES */
 

--- a/SeedPlan.Client/Pages/Home.razor
+++ b/SeedPlan.Client/Pages/Home.razor
@@ -19,7 +19,7 @@
         <div class="header-top">
             <h1 class="serif-title">Välkommen tillbaka</h1>
             <div class="date-badge">
-                <i data-lucide="calendar"></i>
+                <Blazicon Svg="Lucide.Calendar" />
                 <span>@DateTime.Now.ToString("yyyy-MM-dd")</span>
             </div>
         </div>
@@ -38,28 +38,28 @@
                 <h2 class="section-title">AKTIVA SÅDDER</h2>
                 <div class="stats-mini-grid">
                     <div class="mini-stat-card">
-                        <div class="mini-icon blue"><i data-lucide="sprout"></i></div>
-                        <div class="mini-info">
-                            <span class="mini-label">Nysått</span>
-                            <span class="mini-value">@countSown</span>
-                        </div>
-                    </div>
-                    <div class="mini-stat-card">
-                        <div class="mini-icon green"><i data-lucide="check-circle"></i></div>
+                        <div class="mini-icon blue"><Blazicon Svg="Lucide.Sprout" /></div>
                         <div class="mini-info">
                             <span class="mini-label">Grodda</span>
                             <span class="mini-value">@countGerminated</span>
                         </div>
                     </div>
                     <div class="mini-stat-card">
-                        <div class="mini-icon yellow"><i data-lucide="leaf"></i></div>
+                        <div class="mini-icon green"><Blazicon Svg="MdiIcon.Shovel" /></div>
                         <div class="mini-info">
                             <span class="mini-label">Omskolade</span>
                             <span class="mini-value">@countRepotted</span>
                         </div>
                     </div>
                     <div class="mini-stat-card">
-                        <div class="mini-icon purple"><i data-lucide="sun"></i></div>
+                        <div class="mini-icon yellow"><Blazicon Svg="MdiIcon.SunClockOutline" /></div>
+                        <div class="mini-info">
+                            <span class="mini-label">Avhärdade</span>
+                            <span class="mini-value">@countAcclimated</span>
+                        </div>
+                    </div>
+                    <div class="mini-stat-card">
+                        <div class="mini-icon purple"><Blazicon Svg="MdiIcon.BeeFlower" /></div>
                         <div class="mini-info">
                             <span class="mini-label">Utplanterade</span>
                             <span class="mini-value">@countPlantedOut</span>
@@ -79,7 +79,7 @@
                     {
                         <div class="mini-card" @onclick="() => OpenPlantDetail(plant)">
                             <div class="mini-card-content">
-                                <i data-lucide="calendar-x" class="mini-icon"></i>
+                                <div class="mini-icon"><Blazicon Svg="Lucide.CalendarX" /></div>
                                 <span>@plant.PlantName</span>
                             </div>
                             <span class="mini-badge">Passerat</span>
@@ -113,7 +113,7 @@
                     <div class="plant-card" @onclick="() => OpenPlantDetail(item.Plant)">
                         <div class="plant-main">
                             <div class="plant-icon-circle">
-                                <i data-lucide="leaf"></i>
+                                <Blazicon Svg="Lucide.Flower"/>
                             </div>
                             <div class="plant-core-info">
                                 <div class="plant-title-row">
@@ -144,17 +144,17 @@
                                 @if (item.Plant.IsLightGerminating)
                                 {
                                     <div class="feature-icon light" title="Ljusgroende">
-                                    <i data-lucide="sparkles"></i>
+                                    <Blazicon Svg="Lucide.Sparkles"/>
                                     </div>
                                 }
                                 @if (item.Plant.RequiresTopping)
                                 {
                                     <div class="feature-icon topping" title="Ska toppas">
-                                        <i data-lucide="scissors"></i>
+                                       <Blazicon Svg="Lucide.Scissors"/>
                                     </div>
                                 }
                             </div>
-                            <i data-lucide="chevron-right" class="arrow"></i>
+                            <Blazicon Svg="Lucide.ChevronRight" />
                         </div>
                     </div>
                 }
@@ -172,7 +172,7 @@
     private SowingOverview overview = new();
     private List<Sowing> activeSowings = new();
     private List<PlantSowingView> sowingSuggestions = new();
-    private int countSown, countGerminated, countRepotted, countPlantedOut;
+    private int countGerminated, countRepotted, countAcclimated, countPlantedOut;
 
     private bool showDetailModal = false;
     private bool showSowModal = false;
@@ -199,10 +199,10 @@
             // Vi konverterar status till int i jämförelsen för att slippa CS0019
             activeSowings = allSowings.Where(s => (int)s.Status < 7).ToList();
 
-            countSown = activeSowings.Count(s => (int)s.Status == 0);
             countGerminated = activeSowings.Count(s => (int)s.Status >= 1 && (int)s.Status <= 2);
             countRepotted = activeSowings.Count(s => (int)s.Status >= 3 && (int)s.Status <= 4);
-            countPlantedOut = activeSowings.Count(s => (int)s.Status >= 5 && (int)s.Status <= 6);
+            countAcclimated = activeSowings.Count(s => (int)s.Status == 5);
+            countPlantedOut = activeSowings.Count(s => (int)s.Status == 6);
 
 
 
@@ -216,7 +216,6 @@
             isLoading = false;
             StateHasChanged();
             await Task.Delay(200);
-            await JS.InvokeVoidAsync("initializeLucide");
         }
     }
 

--- a/SeedPlan.Client/Pages/Home.razor.css
+++ b/SeedPlan.Client/Pages/Home.razor.css
@@ -14,15 +14,13 @@
     background: white;
     padding: 8px 14px;
     border-radius: 12px;
-    font-size: 0.85rem;
+    font-size: 1rem;
     font-weight: 600;
     color: #64748b;
     border: 1px solid #f1f5f9;
 }
-
-    .date-badge i {
-        width: 16px;
-        color: #10b981;
+    .date-badge span {
+        font-size: 0.85rem;
     }
 /* --- SEKTION FÖR STATISTIK --- */
 
@@ -61,12 +59,9 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    font-size: 1.8rem;
 }
 
-    .mini-icon i {
-        width: 18px;
-        height: 18px;
-    }
 
     /* Färgteman för dina ikoner */
     .mini-icon.blue {
@@ -160,6 +155,7 @@
 .plant-icon-circle {
     width: 48px;
     height: 48px;
+    font-size: 1.5rem;
     background: #f8f8f8;
     border-radius: 50%;
     display: flex;

--- a/SeedPlan.Client/Pages/PlantDetailModal.razor
+++ b/SeedPlan.Client/Pages/PlantDetailModal.razor
@@ -16,7 +16,7 @@
                 <div class="title-with-plus">
                     <h2 class="serif-title">@Plant.PlantName</h2>
                     <button class="expand-btn" @onclick="ToggleAddForm" title="Lägg till frö">
-                        <i data-lucide="plus"></i>
+                        <Blazicon Svg="MdiIcon.SeedPlusOutline"/>
                     </button>
                 </div>
             </header>
@@ -40,7 +40,7 @@
                                     <span class="variety-meta">@seed.Quantity st </span>
                                 </div>
                                 <button class="sow-now-action" @onclick="() => HandleQuickSow(seed)">
-                                    <i data-lucide="plus"></i> Så nu
+                                   <Blazicon Svg="Lucide.Plus" /> Så nu
                                 </button>
                             </div>
                         }
@@ -136,7 +136,6 @@
 
             allVarieties = await PlantService.GetVarietiesForPlantAsync(Plant.Id);
             await Task.Delay(50);
-            await JS.InvokeVoidAsync("initializeLucide");
         }
     }
 

--- a/SeedPlan.Client/Pages/PlantDetailModal.razor.css
+++ b/SeedPlan.Client/Pages/PlantDetailModal.razor.css
@@ -49,6 +49,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    font-size: 1.5rem;
 }
 
     .expand-btn i {

--- a/SeedPlan.Client/Pages/Profile.razor
+++ b/SeedPlan.Client/Pages/Profile.razor
@@ -9,7 +9,7 @@
 
 <div class="profile-container">
     <header class="profile-header">
-        <h1 class="serif-title">Inställningar 🌱</h1>
+        <h1 class="serif-title">Inställningar <Blazicon Svg="MdiIcon.AccountCogOutline" /></h1>
         <p>Anpassa appen efter din trädgårds förutsättningar.</p>
     </header>
 
@@ -36,7 +36,7 @@
         }
 
         <button class="btn-save" @onclick="SaveProfile">
-            <i data-lucide="save"></i> Spara inställningar
+           <Blazicon Svg="Lucide.Save"/>
         </button>
     </div>
 </div>
@@ -82,6 +82,5 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        await JS.InvokeVoidAsync("initializeLucide");
     }
 }

--- a/SeedPlan.Client/Pages/Register.razor
+++ b/SeedPlan.Client/Pages/Register.razor
@@ -8,7 +8,7 @@
 <div class="auth-page-container">
     <div class="auth-header">
         <button class="btn-back" @onclick="GoBack">
-            <i data-lucide="chevron-left"></i> Tillbaka
+            <Blazicon Svg="Lucide.ChevronLeft" /> Tillbaka
         </button>
     </div>
 
@@ -19,8 +19,4 @@
 
     private void GoBack() => Nav.NavigateTo("/");
 
-    protected override async Task OnAfterRenderAsync(bool firstRender)
-    {
-        await JS.InvokeVoidAsync("initializeLucide");
-    }
 }

--- a/SeedPlan.Client/Pages/Seeds.razor
+++ b/SeedPlan.Client/Pages/Seeds.razor
@@ -10,10 +10,10 @@
 
 <div class="seeds-container">
     <header class="seeds-header">
-        <h1 class="serif-title">Mina Fröer 🌱</h1>
+        <h1 class="serif-title">Mina Fröer</h1>
         <div class="control-button">
             <button class="btn-add-seed" title="Lägg till frö" @onclick="OpenAddSeed">
-                <i data-lucide="plus"></i>
+                <div class="btn-add-seed-icon"><Blazicon Svg="MdiIcon.SeedPlusOutline" /></div>
                 <span>Nytt frö</span> @* Texten döljs på mobil med CSS *@
             </button>
         </div>
@@ -26,7 +26,7 @@
     else if (!groupedSeeds.Any())
     {
         <div class="empty-state">
-            <p>Ditt fröbibliotek är tomt. Dags att fylla på! 📦</p>
+            <p>Ditt fröbibliotek är tomt. Dags att fylla på! <Blazicon Svg="MdiIcon.SeedOutline"/></p>
             <button class="btn-primary" @onclick="OpenAddSeed">Lägg till ditt första frö</button>
         </div>
     }
@@ -40,8 +40,17 @@
 
                 <div class="plant-group-header" @onclick="() => ToggleGroup(group.Key)" style="cursor: pointer;">
                     <div class="plant-group-header-main">
+                        <div class="chevron">
                         @* Vi har alltid samma ikon, men lägger till klassen 'expanded' om den är öppen *@
-                        <i data-lucide="flower" class="group-arrow @(isExpanded ? "expanded" : "")"></i>
+                        @if(!isExpanded)
+                        {
+                                <Blazicon Svg="Lucide.ChevronRight" />
+                        }
+                        else
+                        {
+                                <Blazicon Svg="Lucide.ChevronDown" />
+                        }
+                        </div>
                         <h2 class="serif-title">@if (group.Key == "Övrigt")
                             {
                                 @extraSeedGroup                   
@@ -52,7 +61,7 @@
                             }
                         </h2>
                     </div>
-                    <span class="seed-count">@group.Count() sort</span>
+                    <span class="seed-count">@group.Count() sorter</span>
                 </div>
                 @if (isExpanded)
                 {
@@ -72,15 +81,15 @@
                                     }
                                 </div>
                                 <div class="seed-actions">
-                                    <div class="qty-badge">
+                                    <div class="qty-badge" onclick="Open">
                                         @* Din nya ikon för att "stoppa ner frö i jorden" *@
-                                        <i data-lucide="sprout" class="sow-icon"></i>
+                                        <Blazicon Svg="MdiIcon.SeedOutline" />
                                         <span class="qty">@seed.Quantity st</span>
                                     </div>
-                                    <i data-lucide="chevron-right" class="arrow-icon"></i>
+                                    <div class="arrow-icon"><Blazicon Svg="Lucide.ChevronRight" /></div>
                                     @* NY RADERINGSKNAPP *@
                                     <button class="delete-seed-btn" @onclick="() => HandleDelete(seed)" @onclick:stopPropagation="true">
-                                        <i data-lucide="trash-2"></i>
+                                        <Blazicon Svg="Lucide.Trash2" />
                                     </button>
                                 </div>
                             </div>
@@ -119,7 +128,7 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        await JS.InvokeVoidAsync("initializeLucide");
+
     }
 
     private void OpenAddSeed() => showAddModal = true;
@@ -135,7 +144,6 @@
             expandedGroups.Add(plantName);
         }
         await Task.Delay(1);
-        await JS.InvokeVoidAsync("initializeLucide");
     }
 
     private async Task RefreshSeeds()
@@ -144,7 +152,6 @@
         groupedSeeds = await SeedService.GetMySeedsGrouped();
         isLoading = false;
         StateHasChanged();
-        await JS.InvokeVoidAsync("initializeLucide");
     }
 
     private void OpenEditSeed(SeedView seed)

--- a/SeedPlan.Client/Pages/Seeds.razor.css
+++ b/SeedPlan.Client/Pages/Seeds.razor.css
@@ -162,15 +162,14 @@
     font-weight: 500;
     transition: transform 0.1s active, background-color 0.2s;
     white-space: nowrap;
+    font-size: 1.2rem;
+}
+.btn-add-seed span{
+    font-size: 0.9rem;
 }
 
     .btn-add-seed:hover {
         background-color: #047857;
-    }
-
-    .btn-add-seed i {
-        width: 20px !important;
-        height: 20px !important;
     }
 
 .qty-badge {

--- a/SeedPlan.Client/Pages/Sowings.razor
+++ b/SeedPlan.Client/Pages/Sowings.razor
@@ -21,11 +21,10 @@
                 <option value="plant">Gruppera efter växtnamn</option>
                 <option value="date">Gruppera efter sådatum</option>
             </select>
-                <i data-lucide="chevron-down" class="select-arrow"></i>
             </div>
             <div class="control-button">
                 <button class="btn-add-sowing" title="Lägg till sådd" @onclick="OpenAddSowing">
-                    <i data-lucide="plus"></i>
+                    <Blazicon Svg="Lucide.Sprout" />
                     <span>Ny sådd</span> @* Texten döljs på mobil med CSS *@
                 </button>
             </div>
@@ -60,7 +59,7 @@
                         <div class="card-header">
                             <div class="header-main">
                                 <div class="icon-box hide-on-mobile">
-                                    <i data-lucide="@GetStatusIcon(sowing.Status)"></i>
+                                   <Blazicon Svg="@GetStatusIcon(sowing.Status)"/>
                                 </div>
                                 <div class="title-area">
                                     <h3>
@@ -68,7 +67,7 @@
                                         <span class="variety-name">(@(sowing.VarietyName ?? "Okänd sort"))</span>
                                     </h3>
                                     <p class="sown-date">
-                                        <i data-lucide="calendar"></i>
+                                        <Blazicon Svg="Lucide.Calendar" />
                                         @* NYTT: CSS-klass för att dölja text på mobil *@
                                         <span class="hide-on-mobile">Sådd den </span>
                                         @(sowing.SownDate.ToString("yyyy-MM-dd"))
@@ -80,7 +79,7 @@
                             <div class="header-actions">
                                 <span class="status-badge hide-on-mobile">@GetStatusText(sowing.Status)</span>
                                 <button class="delete-btn" @onclick="() => HandleDelete(sowing.Id)">
-                                    <i data-lucide="trash-2"></i>
+                                    <Blazicon Svg="Lucide.Trash2" />
                                 </button>
                             </div>
                             </div>
@@ -89,22 +88,22 @@
                                 <div class="progress-line"></div>
                                 <div class="progress-steps">
                                     <div class="step @(sowing.Status == 0 ? "active" : "")" @onclick="() => UpdateStatus(sowing, 0)"> @* SÅDD *@
-                                        <i data-lucide="bean"></i>
+                                        <Blazicon Svg="MdiIcon.SeedOutline" />
                                     </div>
                                     <div class="step @(sowing.Status == 1 ? "active" : "")" @onclick="() => UpdateStatus(sowing, 1)"> @* GRODD *@
-                                        <i data-lucide="sprout"></i>
+                                       <Blazicon Svg="Lucide.Sprout" />
                                     </div>
                                     <div class="step @(sowing.Status == 2 ? "active" : "")" @onclick="() => UpdateStatus(sowing, 2)"> @*KARAKTÄRSBLAD*@
-                                        <i data-lucide="leaf"></i>
+                                        <Blazicon Svg="Lucide.Leaf"/>
                                     </div>
                                     <div class="step @(sowing.Status == 4 ? "active" : "")" @onclick="() => UpdateStatus(sowing, 4)"> @*OMSKOLNING*@
-                                        <i data-lucide="circle-check-big"></i>
+                                    <Blazicon Svg="MdiIcon.Shovel" />
                                     </div>
                                     <div class="step @(sowing.Status == 5 ? "active" : "")" @onclick="() => UpdateStatus(sowing, 5)"> @*AVHÄRDNING*@
-                                        <i data-lucide="wind"></i>
+                                        <Blazicon Svg="MdiIcon.SunThermometerOutline"/>
                                     </div>
                                     <div class="step @(sowing.Status == 6 ? "active" : "")" @onclick="() => UpdateStatus(sowing, 6)"> @*UTPLANTERING*@
-                                        <i data-lucide="sun"></i>
+                                    <Blazicon Svg="MdiIcon.BeeFlower" />
                                     </div>
                                 </div>
                             </div>
@@ -113,7 +112,7 @@
                             @if (sowing.Status == 0)
                             {
                                 <div class="info-box">
-                                    <i data-lucide="info"></i>
+                                    <Blazicon Svg="Lucide.Info" />
                                     <span>
                                     Sås på <strong>@(sowing.SowingDepth ?? 0) mm djup</strong>.
                                         @(sowing.IsLightGerminating == true ? $"{sowing.PlantName} är ljusgroende." : "")
@@ -123,7 +122,7 @@
                             @if (sowing.Status == 2 && sowing.RequiresTopping == true)
                             {
                                 <div class="info-box">
-                                    <i data-lucide="info"></i>
+                                    <Blazicon Svg="Lucide.Info" />
                                     <span>
                                         @(sowing.PlantName ?? "Växten") bör toppas!
                                     </span>
@@ -153,18 +152,12 @@
         await LoadSowings();
     }
 
-    protected override async Task OnAfterRenderAsync(bool firstRender)
-    {
-        await JS.InvokeVoidAsync("initializeLucide");
-    }
-
     private async Task LoadSowings()
     {
         isLoading = true;
         mySowings = await SowingService.GetMySowingViews();
         isLoading = false;
 
-        await JS.InvokeVoidAsync("initializeLucide");
         StateHasChanged();
     }
 
@@ -204,14 +197,15 @@
         _ => "AKTIV"
     };
 
-    private string GetStatusIcon(int status) => status switch
+    private SvgIcon GetStatusIcon(int status) => status switch
     {
-        0 => "sprout",
-        1 => "check-circle",
-        2 => "leaf",
-        5 => "wind",
-        6 => "sun",
-        _ => "sprout"
+        0 => MdiIcon.SeedOutline,
+        1 => Lucide.Sprout,
+        2 => Lucide.Leaf,
+        3 => MdiIcon.Shovel,
+        5 => MdiIcon.SunClockOutline,
+        6 => MdiIcon.BeeFlower,
+        _ => Lucide.Sprout
     };
 
     private async Task UpdateStatus(SowingView sowing, int newStatus)
@@ -219,7 +213,6 @@
         sowing.Status = newStatus;
         await SowingService.UpdateSowingStatus(sowing.Id, newStatus);
 
-        await JS.InvokeVoidAsync("initializeLucide");
         StateHasChanged();
     }
 

--- a/SeedPlan.Client/Pages/Sowings.razor.css
+++ b/SeedPlan.Client/Pages/Sowings.razor.css
@@ -26,6 +26,10 @@
     font-weight: 500;
     transition: transform 0.1s active, background-color 0.2s;
     white-space: nowrap;
+    font-size: 1rem;
+}
+.btn-add-sowing span {
+    font-size: 0.8rem;
 }
 
     .btn-add-sowing:hover {
@@ -68,6 +72,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    font-size: 1.5rem;
 }
 
 .title-area h3 {
@@ -121,6 +126,7 @@
     color: #cbd5e1;
     cursor: pointer;
     padding: 5px;
+    font-size: 1.1rem;
 }
 
     .delete-btn:hover {
@@ -163,12 +169,9 @@
     color: #cbd5e1;
     cursor: pointer;
     transition: all 0.2s ease;
+    font-size: 1.5rem;
 }
 
-    .step i {
-        width: 18px;
-        height: 18px;
-    }
 
     .step.active {
         background: #10b981;

--- a/SeedPlan.Client/SeedPlan.Client.csproj
+++ b/SeedPlan.Client/SeedPlan.Client.csproj
@@ -10,7 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="8.0.0" />
+    <PackageReference Include="Blazicons" Version="3.0.12" />
+    <PackageReference Include="Blazicons.Lucide" Version="2.1.3" />
+    <PackageReference Include="Blazicons.MaterialDesignIcons" Version="3.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="8.0.11" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.0" />
     <PackageReference Include="Supabase" Version="1.1.1" />
   </ItemGroup>

--- a/SeedPlan.Client/Shared/LoginDisplay.razor
+++ b/SeedPlan.Client/Shared/LoginDisplay.razor
@@ -13,13 +13,13 @@
             <span class="user-display-name">@displayName</span>
             
             @* 2. Sol-ikonen i mitten *@
-            <div class="theme-toggle-header">
+           @* <div class="theme-toggle-header">
                 <i data-lucide="sun"></i>
-            </div>
+            </div>*@
             
             @* 3. Utloggnings-ikonen sist *@
             <button class="logout-icon-btn" @onclick="HandleLogout" title="Logga ut">
-                <i data-lucide="log-out"></i>
+                <Blazicon Svg="Lucide.LogOut" />
             </button>
         </div>
     </Authorized>

--- a/SeedPlan.Client/Shared/LoginDisplay.razor.css
+++ b/SeedPlan.Client/Shared/LoginDisplay.razor.css
@@ -68,8 +68,8 @@
     background: #fee2e2;
     color: #ef4444;
     border: none;
-    width: 34px;
-    height: 34px;
+    font-size: 1.2rem;
+    padding: 6px;
     border-radius: 50%;
     display: flex;
     align-items: center;

--- a/SeedPlan.Client/_Imports.razor
+++ b/SeedPlan.Client/_Imports.razor
@@ -12,3 +12,4 @@
 @using SeedPlan.Client.Shared
 @using SeedPlan.Shared.Interfaces
 @using SeedPlan.Shared.Models
+@using Blazicons

--- a/SeedPlan/Components/App.razor
+++ b/SeedPlan/Components/App.razor
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="app.css" />
     <link rel="stylesheet" href="components.css" /> @* Din nya fil för gemensamma element *@
     <link rel="stylesheet" href="SeedPlan.styles.css" /> @* Denna behövs för isolerad CSS (t.ex. .razor.css) *@
+    <link href="_content/Blazicons/css/blazicons.min.css" rel="stylesheet" />
     <link rel="manifest" href="manifest.webmanifest">
     
     @* Laddar Lucide-ikonerna *@


### PR DESCRIPTION
Replaced all <i data-lucide="..."> icon usage with <Blazicon Svg="..."/> components using Lucide and Material Design Icons. Removed all JS-based Lucide initialization and related scripts. Updated CSS for new icon components and improved sizing. Added Blazicons NuGet packages and CSS. Adjusted some icon choices and UI labels for clarity. This refactor improves maintainability, performance, and accessibility by rendering icons natively in Blazor.