### PR TITLE
Debounced Dahlia search, improved UX, and QA tests

### DIFF
--- a/SeedPlan.Client.UnitTests/Flows/Prio1StaticQaChecksTests.cs
+++ b/SeedPlan.Client.UnitTests/Flows/Prio1StaticQaChecksTests.cs
@@ -1,0 +1,69 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+
+namespace SeedPlan.Client.UnitTests.Flows;
+
+[TestClass]
+public class Prio1StaticQaChecksTests
+{
+    [TestMethod]
+    public void VersionChain_IsConsistentAcrossMainLayout_Settings_AndAppSettings()
+    {
+        var root = GetRepoRoot();
+        var mainLayoutPath = Path.Combine(root, "SeedPlan.Client", "Layout", "MainLayout.razor");
+        var settingsPath = Path.Combine(root, "SeedPlan.Client", "Pages", "Settings.razor");
+        var appSettingsPath = Path.Combine(root, "SeedPlan.Client", "wwwroot", "appsettings.json");
+
+        var mainLayout = File.ReadAllText(mainLayoutPath);
+        var settings = File.ReadAllText(settingsPath);
+        var appSettings = File.ReadAllText(appSettingsPath);
+
+        Assert.IsTrue(mainLayout.Contains("CurrentAppVersion = \"1.5.1\""), "MainLayout app version should be 1.5.1.");
+        Assert.IsTrue(settings.Contains("SeedPlan v.1.5.1"), "Settings page should show version 1.5.1.");
+
+        using var json = JsonDocument.Parse(appSettings);
+        var appVersion = json.RootElement.GetProperty("AppVersion").GetString();
+        Assert.AreEqual("1.5.1", appVersion, "appsettings.json AppVersion should be 1.5.1.");
+    }
+
+    [TestMethod]
+    public void ModeSwitch_AndModeSpecificBottomNav_AreConfigured()
+    {
+        var root = GetRepoRoot();
+        var mainLayoutPath = Path.Combine(root, "SeedPlan.Client", "Layout", "MainLayout.razor");
+        var bottomNavPath = Path.Combine(root, "SeedPlan.Client", "Layout", "BottomNav.razor");
+
+        var mainLayout = File.ReadAllText(mainLayoutPath);
+        var bottomNav = File.ReadAllText(bottomNavPath);
+
+        Assert.IsTrue(mainLayout.Contains("localStorage.getItem", StringComparison.Ordinal), "MainLayout should read persisted mode from localStorage.");
+        Assert.IsTrue(mainLayout.Contains("localStorage.setItem", StringComparison.Ordinal), "MainLayout should persist mode to localStorage.");
+        Assert.IsTrue(mainLayout.Contains("appMode", StringComparison.Ordinal), "MainLayout should use the appMode key.");
+        Assert.IsTrue(mainLayout.Contains("/dahliabox-home", StringComparison.Ordinal), "MainLayout should navigate to DahliaBox home for Dahlia mode.");
+
+        Assert.IsTrue(bottomNav.Contains("AppMode.SeedPlan", StringComparison.Ordinal), "BottomNav should have a SeedPlan mode branch.");
+        Assert.IsTrue(bottomNav.Contains("AppMode.DahliaBox", StringComparison.Ordinal), "BottomNav should have a DahliaBox mode branch.");
+        Assert.IsTrue(bottomNav.Contains("href=\"seeds\"", StringComparison.Ordinal), "SeedPlan mode should include seeds navigation.");
+        Assert.IsTrue(bottomNav.Contains("href=\"sowings\"", StringComparison.Ordinal), "SeedPlan mode should include sowings navigation.");
+        Assert.IsTrue(bottomNav.Contains("href=\"guide\"", StringComparison.Ordinal), "SeedPlan mode should include guide navigation.");
+        Assert.IsTrue(bottomNav.Contains("href=\"dahliabox-home\"", StringComparison.Ordinal), "Dahlia mode should include dashboard navigation.");
+        Assert.IsTrue(bottomNav.Contains("href=\"tubers\"", StringComparison.Ordinal), "Dahlia mode should include tubers navigation.");
+        Assert.IsTrue(bottomNav.Contains("href=\"dahlias\"", StringComparison.Ordinal), "Dahlia mode should include varieties navigation.");
+    }
+
+    private static string GetRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "SeedPlan.slnx")))
+            {
+                return dir.FullName;
+            }
+
+            dir = dir.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate repository root from test execution directory.");
+    }
+}

--- a/SeedPlan.Client.UnitTests/Flows/Prio1UiBehaviorTests.cs
+++ b/SeedPlan.Client.UnitTests/Flows/Prio1UiBehaviorTests.cs
@@ -1,0 +1,162 @@
+using System.Reflection;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Forms;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using SeedPlan.Client.Components.Functions;
+using SeedPlan.Client.Components.Modals;
+using SeedPlan.Shared.Interfaces;
+using SeedPlan.Shared.Models;
+
+namespace SeedPlan.Client.UnitTests.Flows;
+
+[TestClass]
+public class Prio1UiBehaviorTests
+{
+    [TestMethod]
+    public async Task AddDahliaModal_OnSearchInput_WithTwoOrMoreChars_PerformsAsyncSearchAndStoresResults()
+    {
+        var dahliaService = new Mock<IDahliaService>();
+        var expected = new List<Dahlia>
+        {
+            new() { Id = "d-1", Name = "Cafe au Lait" }
+        };
+
+        dahliaService
+            .Setup(s => s.SearchDahliasAsync("cafe"))
+            .ReturnsAsync(expected);
+
+        var component = new AddDahliaModal
+        {
+        };
+        SetInjectMember(component, "DahliaService", dahliaService.Object);
+
+        await InvokePrivateAsync(component, "OnSearchInput", new ChangeEventArgs { Value = "cafe" });
+
+        var searchResults = GetPrivateField<List<Dahlia>>(component, "searchResults");
+        var isSearching = GetPrivateField<bool>(component, "isSearching");
+
+        Assert.AreEqual(1, searchResults.Count);
+        Assert.AreEqual("Cafe au Lait", searchResults[0].Name);
+        Assert.IsFalse(isSearching);
+        dahliaService.Verify(s => s.SearchDahliasAsync("cafe"), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task AddDahliaModal_OnSearchInput_WithShortTerm_ClearsResultsAndSkipsSearch()
+    {
+        var dahliaService = new Mock<IDahliaService>();
+        var component = new AddDahliaModal
+        {
+        };
+        SetInjectMember(component, "DahliaService", dahliaService.Object);
+
+        await InvokePrivateAsync(component, "OnSearchInput", new ChangeEventArgs { Value = "a" });
+
+        var searchResults = GetPrivateField<List<Dahlia>>(component, "searchResults");
+        var isSearching = GetPrivateField<bool>(component, "isSearching");
+
+        Assert.AreEqual(0, searchResults.Count);
+        Assert.IsFalse(isSearching);
+        dahliaService.Verify(s => s.SearchDahliasAsync(It.IsAny<string>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task AddDahliaModal_SelectResult_UpdatesSelectionAndClearsSearchState()
+    {
+        var component = new AddDahliaModal();
+        var selected = new Dahlia { Id = "d-2", Name = "Wizard of Oz" };
+
+        SetPrivateField(component, "searchText", "wizard");
+        SetPrivateField(component, "searchResults", new List<Dahlia> { selected });
+
+        InvokePrivate(component, "SelectResult", selected);
+
+        var isSelected = GetPrivateField<bool>(component, "isDahliaSelected");
+        var searchText = GetPrivateField<string>(component, "searchText");
+        var searchResults = GetPrivateField<List<Dahlia>>(component, "searchResults");
+        var newDahlia = GetPrivateField<UserDahlia>(component, "newDahlia");
+
+        Assert.IsTrue(isSelected);
+        Assert.AreEqual(string.Empty, searchText);
+        Assert.AreEqual(0, searchResults.Count);
+        Assert.AreEqual("d-2", newDahlia.VarietyId);
+        Assert.IsNotNull(newDahlia.Variety);
+        Assert.AreEqual("Wizard of Oz", newDahlia.Variety.Name);
+    }
+
+    [TestMethod]
+    public async Task StarRating_WhenClickingSameStar_TogglesToNull()
+    {
+        var component = new StarRating { Rating = 3 };
+        int? callbackValue = -1;
+        component.RatingChanged = EventCallback.Factory.Create<int?>(this, v => callbackValue = v);
+
+        await InvokePrivateAsync(component, "HandleClick", 3);
+
+        Assert.IsNull(callbackValue);
+    }
+
+    [TestMethod]
+    public async Task StarRating_WhenClickingDifferentStar_EmitsNewValue()
+    {
+        var component = new StarRating { Rating = 2 };
+        int? callbackValue = null;
+        component.RatingChanged = EventCallback.Factory.Create<int?>(this, v => callbackValue = v);
+
+        await InvokePrivateAsync(component, "HandleClick", 5);
+
+        Assert.AreEqual(5, callbackValue);
+    }
+
+    private static void InvokePrivate(object target, string methodName, params object[] args)
+    {
+        var method = target.GetType().GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.IsNotNull(method, $"Method '{methodName}' was not found on {target.GetType().Name}.");
+        method.Invoke(target, args);
+    }
+
+    private static async Task InvokePrivateAsync(object target, string methodName, params object[] args)
+    {
+        var method = target.GetType().GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.IsNotNull(method, $"Method '{methodName}' was not found on {target.GetType().Name}.");
+
+        var result = method.Invoke(target, args);
+        if (result is Task task)
+        {
+            await task;
+        }
+    }
+
+    private static T GetPrivateField<T>(object target, string fieldName)
+    {
+        var field = target.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.IsNotNull(field, $"Field '{fieldName}' was not found on {target.GetType().Name}.");
+        return (T)field.GetValue(target)!;
+    }
+
+    private static void SetPrivateField(object target, string fieldName, object value)
+    {
+        var field = target.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.IsNotNull(field, $"Field '{fieldName}' was not found on {target.GetType().Name}.");
+        field.SetValue(target, value);
+    }
+
+    private static void SetInjectMember(object target, string memberName, object value)
+    {
+        var type = target.GetType();
+
+        var property = type.GetProperty(memberName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        if (property != null)
+        {
+            property.SetValue(target, value);
+            return;
+        }
+
+        var field = type.GetField(memberName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+            ?? type.GetField(char.ToLowerInvariant(memberName[0]) + memberName[1..], BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+
+        Assert.IsNotNull(field, $"Inject member '{memberName}' was not found on {type.Name}.");
+        field.SetValue(target, value);
+    }
+}

--- a/SeedPlan.Client/Components/Modals/AddDahliaModal.razor
+++ b/SeedPlan.Client/Components/Modals/AddDahliaModal.razor
@@ -6,6 +6,7 @@
 @using Cropper.Blazor.Exceptions
 @using Cropper.Blazor.Models
 @using System.Text.RegularExpressions
+@implements IDisposable
 
 @if (IsVisible)
 {
@@ -30,16 +31,31 @@
                         @if (!string.IsNullOrEmpty(searchText))
                         {
                             <div class="sp-dropdown">
-                                @foreach (var dahlia in searchResults)
+                                @if (isSearching)
                                 {
-                                    <div class="sp-dropdown-item" @onclick="() => SelectResult(dahlia)">
-                                        <span>@dahlia.Name</span>
+                                    <div class="sp-dropdown-item sp-loading-item">
+                                        <span>Söker sorter...</span>
                                     </div>
                                 }
-                           
-                            <div class="sp-dropdown-item create-new-item" @onclick="PrepareToCreateNew">
-                                <span>➕ Skapa ny sort: "@searchText"</span>
-                            </div>
+                                else if (searchResults.Any())
+                                {
+                                    @foreach (var dahlia in searchResults)
+                                    {
+                                        <div class="sp-dropdown-item" @onclick="() => SelectResult(dahlia)">
+                                            <span>@dahlia.Name</span>
+                                        </div>
+                                    }
+                                }
+                                else
+                                {
+                                    <div class="sp-dropdown-item sp-empty-state">
+                                        <span>Inga träffar hittades.</span>
+                                    </div>
+                                }
+
+                                <div class="sp-dropdown-item create-new-item" @onclick="PrepareToCreateNew">
+                                    <span>➕ Skapa ny sort: "@searchText"</span>
+                                </div>
                             </div>
                         }
                     }
@@ -161,8 +177,10 @@
     [Parameter] public EventCallback OnClose { get; set; }
     [Parameter] public EventCallback OnSaved { get; set; }
 
+    private const int SearchDebounceMs = 250;
     private List<Dahlia> searchResults = new();
     private bool isSearching = false;
+    private CancellationTokenSource? searchCts;
     private bool isCreatingNewVariety = false;
     private Dahlia customVariety = new Dahlia(); 
     private string searchText = "";
@@ -190,35 +208,81 @@
     private async Task OnSearchInput(ChangeEventArgs e)
     {
         searchText = e.Value?.ToString() ?? "";
+        CancelPendingSearch();
 
-        if (searchText.Length > 1)
+        var trimmedSearch = searchText.Trim();
+        if (trimmedSearch.Length <= 1)
         {
-            isSearching = true;
-            // Comment translated to English.
-            var results = await DahliaService.SearchDahliasAsync(searchText);
-            searchResults = results.ToList();
             isSearching = false;
-        }
-        else
-        {
             searchResults.Clear();
+            return;
+        }
+
+        var cts = new CancellationTokenSource();
+        searchCts = cts;
+        isSearching = true;
+
+        try
+        {
+            await Task.Delay(SearchDebounceMs, cts.Token);
+            var results = await DahliaService.SearchDahliasAsync(trimmedSearch);
+
+            if (cts.IsCancellationRequested)
+            {
+                return;
+            }
+
+            searchResults = results.ToList();
+        }
+        catch (TaskCanceledException)
+        {
+            // Ignore cancellation, a newer search input has already started.
+        }
+        finally
+        {
+            if (ReferenceEquals(searchCts, cts))
+            {
+                isSearching = false;
+                searchCts = null;
+            }
+
+            cts.Dispose();
         }
     }
+
+    private void CancelPendingSearch()
+    {
+        if (searchCts == null)
+        {
+            return;
+        }
+
+        searchCts.Cancel();
+        searchCts.Dispose();
+        searchCts = null;
+    }
+
     private void SelectResult(Dahlia res)
     {
+        CancelPendingSearch();
         selectedDahlia = res;
         newDahlia.VarietyId = res.Id;
         newDahlia.Variety = res;
         searchText = "";
+        searchResults.Clear();
+        isSearching = false;
         isDahliaSelected = true;
     }
 
     private void ChangePlant()
     {
+        CancelPendingSearch();
         selectedDahlia = null;
         newDahlia.Id = 0;
         newDahlia.VarietyId = ""; 
         newDahlia.Variety = null;
+        searchResults.Clear();
+        isSearching = false;
         isDahliaSelected = false;
     }
 
@@ -339,4 +403,9 @@
         DahliaType.Stellar => "Stellar",
         _ => type.ToString()
     };
+
+    public void Dispose()
+    {
+        CancelPendingSearch();
+    }
 }

--- a/SeedPlan.Client/Components/Modals/AddDahliaModal.razor.css
+++ b/SeedPlan.Client/Components/Modals/AddDahliaModal.razor.css
@@ -40,6 +40,14 @@
 }
 
 /* SEARCH DROPDOWN STYLING */
+.sp-loading-item {
+    color: #475569;
+    font-style: italic;
+}
+
+.sp-empty-state {
+    color: #64748b;
+}
 
 
 .sp-dropdown-item:last-child {


### PR DESCRIPTION
- Add debounced async search to AddDahliaModal with cancellation and improved dropdown UI (loading, empty, always "create new")
- Implement IDisposable for cleanup of pending searches
- Add styles for loading and empty states in search dropdown
- Add Prio1StaticQaChecksTests and Prio1UiBehaviorTests for version, navigation, and UI behavior validation
- Improves user experience, prevents race conditions, and strengthens automated QA coverage