### PR TITLE
Add hardiness level support and grouping to sowings

### DIFF
--- a/SeedPlan.Client/Components/Cards/SowingCard.razor
+++ b/SeedPlan.Client/Components/Cards/SowingCard.razor
@@ -19,6 +19,10 @@
                         <span class="batch-badge"><Blazicon Svg="Lucide.Repeat" /> @sowing.BatchNumber</span>
                     }
                 </div>
+                <div class="hardiness-badge @GetHardinessClass(sowing.HardinessLevel)">
+                    <span class="full-text">@GetHardinessText(sowing.HardinessLevel)</span>
+                    <span class="short-text">@GetShortHardinessText(sowing.HardinessLevel)</span>
+                </div>
             </div>
         </div>
 
@@ -95,4 +99,8 @@
         99 => Lucide.TriangleAlert,
         _ => Lucide.Sprout
     };
+
+    private string GetHardinessText(int level) => level switch { 0 => "Känslig", 1 => "Halvhärdig", 2 => "Härdig", _ => "" };
+    private string GetHardinessClass(int level) => level switch { 0 => "sensitive", 1 => "half-hardy", 2 => "hardy", _ => "" };
+    private string GetShortHardinessText(int level) => level switch { 0 => "K", 1 => "HH", 2 => "H", _ => "" };
 }

--- a/SeedPlan.Client/Components/Cards/SowingCard.razor.css
+++ b/SeedPlan.Client/Components/Cards/SowingCard.razor.css
@@ -228,3 +228,13 @@
     white-space: nowrap;
     flex-shrink: 0;
 }
+.hardiness-badge {
+    position: absolute;
+    top: 0;
+    right: 0;
+    font-size: 0.65rem;
+    font-weight: 600;
+    padding: 4px 8px;
+    border-radius: 8px;
+    text-transform: uppercase;
+}

--- a/SeedPlan.Client/Pages/Sowings.razor
+++ b/SeedPlan.Client/Pages/Sowings.razor
@@ -189,12 +189,18 @@
             .OrderBy(s => s.SownDate)
             .GroupBy(s => s.SownDate.ToString("yyyy-MM-dd"));
         }
+        if(currentGrouping == "hardiness")
+        {
+            return filtreredList
+            .OrderBy(s => s.HardinessLevel)
+            .GroupBy(s => GetHardinessString(s.HardinessLevel));
+        }
         return filtreredList
             .OrderByDescending(s => s.SownDate)
             .GroupBy(s => "");
     }
 
- 
+
     /// <summary>
     /// Converts a numerical status code into its corresponding localized display text.
     /// </summary>
@@ -213,4 +219,7 @@
         99 => "MISSLYCKAD",
         _ => "OKÄND"
     };
+
+    private string GetHardinessString(int level) => level switch { 0 => "Känslig", 1 => "Halvhärdig", 2 => "Härdig", _ => "" };
+
 }

--- a/Shared/Models/ViewModels/SowingView.cs
+++ b/Shared/Models/ViewModels/SowingView.cs
@@ -54,5 +54,7 @@ namespace SeedPlan.Shared.Models.ViewModels
 
         [Column("batch_number")]
         public int BatchNumber { get; set; }
+        [Column("hardiness_level")]
+        public int HardinessLevel { get; set; }
     }
 }


### PR DESCRIPTION
Added HardinessLevel to SowingView and database mapping. Displayed a hardiness badge in SowingCard with full and short text, styled via a new CSS class. Introduced helper methods for hardiness display. Enabled grouping of sowings by hardiness level in Sowings.razor with localized group headers.